### PR TITLE
[add]endpoint-report [fix]これまでのコントローラーの関数の分岐

### DIFF
--- a/app/Http/Controllers/FavoriteController.php
+++ b/app/Http/Controllers/FavoriteController.php
@@ -6,7 +6,16 @@ use Illuminate\Http\Request;
 
 class FavoriteController extends Controller
 {
-    public function action_index(Request $request){
+    public function action_index_post(Request $request){
+        try{
+            return response()->json([], 200);
+        } catch (\GuzzleHttp\Exception\ClientException $e) {
+            $errorResponse = $e->getResponse();
+            $errorContent = $errorResponse->getBody()->getContents();
+            return response()->json(json_decode($errorContent, true), $errorResponse->getStatusCode());
+        }
+    }
+    public function action_index_delete(Request $request){
         try{
             return response()->json([], 200);
         } catch (\GuzzleHttp\Exception\ClientException $e) {

--- a/app/Http/Controllers/ReportController.php
+++ b/app/Http/Controllers/ReportController.php
@@ -4,8 +4,17 @@ namespace App\Http\Controllers;
 
 use Illuminate\Http\Request;
 
-class QuestionController extends Controller
+class ReportController extends Controller
 {
+    public function action_index_get(Request $request){
+        try{
+            return response()->json([], 200);
+        } catch (\GuzzleHttp\Exception\ClientException $e) {
+            $errorResponse = $e->getResponse();
+            $errorContent = $errorResponse->getBody()->getContents();
+            return response()->json(json_decode($errorContent, true), $errorResponse->getStatusCode());
+        }
+    }
     public function action_index_post(Request $request){
         try{
             return response()->json([], 200);

--- a/routes/api.php
+++ b/routes/api.php
@@ -5,6 +5,7 @@ use Illuminate\Support\Facades\Route;
 use App\Http\Controllers\LineLoginController;
 use App\Http\Controllers\FavoriteController;
 use App\Http\Controllers\QuestionController;
+use App\Http\Controllers\ReportController;
 
 /*
 |--------------------------------------------------------------------------
@@ -21,7 +22,10 @@ Route::middleware('auth:sanctum')->get('/user', function (Request $request) {
     return $request->user();
 });
 Route::post('/line', [LineLoginController::class, 'action_index']);
-Route::post('/favorite', [FavoriteController::class, 'action_index']);
-Route::delete('/favorite', [FavoriteController::class, 'action_index']);
-Route::post('/question', [QuestionController::class, 'action_index']);
-Route::delete('/question', [QuestionController::class, 'action_index']);
+Route::post('/favorite', [FavoriteController::class, 'action_index_post']);
+Route::delete('/favorite', [FavoriteController::class, 'action_index_delete']);
+Route::post('/question', [QuestionController::class, 'action_index_post']);
+Route::delete('/question', [QuestionController::class, 'action_index_delete']);
+Route::get('/report', [ReportController::class, 'action_index_get']);
+Route::post('/report', [ReportController::class, 'action_index_post']);
+Route::delete('/report', [ReportController::class, 'action_index_delete']);


### PR DESCRIPTION
# 要件定義 ※
reportのエンドポイントの型を作った
他のコントローラの処理を分岐した


# やったこと、なぜこうしたか ※
- api.phpにルーティング追加
- reportコントローラー作成(空のjsonデータを返す)